### PR TITLE
Add broadcast_tensors alias, modify result_type

### DIFF
--- a/array_api_compat/paddle/_aliases.py
+++ b/array_api_compat/paddle/_aliases.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import builtins
 from typing import Literal
 import numpy as np
 

--- a/array_api_compat/paddle/_aliases.py
+++ b/array_api_compat/paddle/_aliases.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 from typing import Literal
 import numpy as np
 
@@ -112,25 +113,32 @@ def result_type(*arrays_and_dtypes: Union[array, Dtype]) -> Dtype:
         raise TypeError("At least one array or dtype must be provided")
     if len(arrays_and_dtypes) == 1:
         x = arrays_and_dtypes[0]
-        if isinstance(x, paddle.dtype):
-            return x
-        return x.dtype
+        return x if isinstance(x, paddle.dtype) else x.dtype
     if len(arrays_and_dtypes) > 2:
         return result_type(arrays_and_dtypes[0], result_type(*arrays_and_dtypes[1:]))
 
     x, y = arrays_and_dtypes
-    xdt = x.dtype if not isinstance(x, paddle.dtype) else x
-    ydt = y.dtype if not isinstance(y, paddle.dtype) else y
+    xdt = x if isinstance(x, paddle.dtype) else x.dtype
+    ydt = y if isinstance(y, paddle.dtype) else y.dtype
 
     if (xdt, ydt) in _promotion_table:
-        return _promotion_table[xdt, ydt]
+        return _promotion_table[(xdt, ydt)]
 
-    # This doesn't result_type(dtype, dtype) for non-array API dtypes
-    # because paddle.result_type only accepts tensors. This does however, allow
-    # cross-kind promotion.
-    x = paddle.to_tensor([], dtype=x) if isinstance(x, paddle.dtype) else x
-    y = paddle.to_tensor([], dtype=y) if isinstance(y, paddle.dtype) else y
-    return paddle.result_type(x, y)
+    type_order = {
+        paddle.bool: 0,
+        paddle.int8: 1,
+        paddle.uint8: 2,
+        paddle.int16: 3,
+        paddle.int32: 4,
+        paddle.int64: 5,
+        paddle.float16: 6,
+        paddle.float32: 7,
+        paddle.float64: 8,
+        paddle.complex64: 9,
+        paddle.complex128: 10
+    }
+    
+    return xdt if type_order.get(xdt, 0) > type_order.get(ydt, 0) else ydt
 
 
 def can_cast(from_: Union[Dtype, array], to: Dtype, /) -> bool:
@@ -922,7 +930,15 @@ def astype(
 
 
 def broadcast_arrays(*arrays: array) -> List[array]:
-    return paddle.broadcast_tensors(arrays)
+    original_dtypes = [arr.dtype for arr in arrays]
+    if len(set(original_dtypes)) == 1:
+        return paddle.broadcast_tensors(arrays)
+    target_dtype = result_type(*arrays)
+    casted_arrays = [arr.astype(target_dtype) if arr.dtype != target_dtype else arr 
+                    for arr in arrays]
+    broadcasted = paddle.broadcast_tensors(casted_arrays)
+    result = [arr.astype(original_dtype) for arr, original_dtype in zip(broadcasted, original_dtypes)]
+    return result
 
 
 # Note that these named tuples aren't actually part of the standard namespace,


### PR DESCRIPTION
详见 https://github.com/PaddlePaddle/Paddle/pull/71788

- 为 broadcast_tensors 增加 alias：因为输入的 tensors 有不同的 dtype，需要将所有 tensors cast 为统一的最高类型，经 paddle.broadcast_tensors 后再 cast 为初始类型，满足测试要求
- 修改 result_type ，返回可提升的最高类型

测试结果：

![image](https://github.com/user-attachments/assets/b037ea6b-d8f6-402a-9e78-8e9e78501102)

@HydrogenSulfate 